### PR TITLE
Pr29 help new impl

### DIFF
--- a/src/cli/cli-handler.c
+++ b/src/cli/cli-handler.c
@@ -83,9 +83,8 @@ int prompt_prototype(InputBuf *buf, int argc, char *args[]){
     while (true){
       printf(">>> ");
       char prompt_input[1000];
-      // Read the entire line
       if (fgets(prompt_input, sizeof(prompt_input), stdin) == NULL) {
-          break;  // Handle EOF if needed
+          break;  // EOF
       }
       // Remove the newline character at the end of the input
       size_t len = strlen(prompt_input);

--- a/src/cli/cli-handler.c
+++ b/src/cli/cli-handler.c
@@ -40,14 +40,14 @@ struct InputBuf {
 
 void animate_intro() {
     char intro[] = "Welcome to Mogwarts University!";
-    int len = strlen(intro);
-    int index = 0;
+    size_t len = strlen(intro);
+    size_t index = 0;
 
     while (index < len) {
         printf(CLEAR_SCREEN);  // Clear the console
         printf(GREEN BOLD);    // Set text color and style
 
-        for (int i = 0; i < len; i++) {
+        for (size_t i = 0; i < len; i++) {
             if (i == index) {
                 printf("%c", toupper(intro[i]));  // Uppercase the current character
             } else {
@@ -101,13 +101,11 @@ int prompt_prototype(InputBuf *buf, int argc, char *args[]){
       smoldb_input_buf_read(buf, prompt_input);
       if (strcmp(prompt_input, "mogging") == 0){
         printf(YELLOW BOLD "Bro can rizz now!\n" RESET_ALL);
-        exit(0);
         return 0;        
       }
     }
   }
   printf(BOLD "\nBro is NOT Jordan Barrett\n" RESET_ALL);
-  exit(1);
   return 1;
 }
 
@@ -137,8 +135,10 @@ static int smoldb_input_buf_read(InputBuf *buf, const char *input){
     perror(RED BOLD "Point to NULL\n" RESET_ALL);
     return SMOLDB_NULL_PTR_TO_REF_ERR;
   }
-  int length = strlen(input);
-  buf->buffer = realloc(buf->buffer, length + 1);
+  size_t length = strlen(input);
+  free(buf->buffer);
+
+  buf->buffer = (char*)malloc(sizeof(char)*(1 + length));
   if (buf->buffer == NULL){
     perror(RED BOLD "Error allocating memory!\n" RESET_ALL);
     return SMOLDB_ALLOC_ERR;

--- a/src/cli/cli-handler.c
+++ b/src/cli/cli-handler.c
@@ -5,10 +5,8 @@
 #include <stdbool.h>
 #include <string.h>
 #include <ctype.h>
-#include <time.h>  // For usleep function
+#include <time.h>
 #include "retval.h"
-
-// I will define some styling here:
 
 #define RESET_ALL "\033[0m"
 
@@ -44,25 +42,25 @@ void animate_intro() {
     size_t index = 0;
 
     while (index < len) {
-        printf(CLEAR_SCREEN);  // Clear the console
-        printf(GREEN BOLD);    // Set text color and style
+        printf(CLEAR_SCREEN);
+        printf(GREEN BOLD); 
 
         for (size_t i = 0; i < len; i++) {
             if (i == index) {
-                printf("%c", toupper(intro[i]));  // Uppercase the current character
+                printf("%c", toupper(intro[i]));
             } else {
                 printf("%c", intro[i]);
             }
         }
 
-        printf(RESET_ALL);  // Reset text attributes
-        fflush(stdout);     // Flush the output buffer
-        // Create a timespec structure for nanosleep
+        printf(RESET_ALL);    
+        fflush(stdout);         
+
         struct timespec req;
         req.tv_sec = 0;
-        req.tv_nsec = 100000000L;  // 100 milliseconds
-        nanosleep(&req, NULL);     // Sleep for the specified time
-        index++;            // Move to the next character
+        req.tv_nsec = 100000000L;  
+        nanosleep(&req, NULL);     
+        index++;            
     }
     printf("\n");
 }
@@ -124,7 +122,9 @@ int smoldb_new_input_buf(InputBuf **buf) {
   return SMOLDB_ALLOC_SUCCESS;
 }
 /**
- * @brief Helper function to read input and write to buffer. This function reallocates the buffer contained inside 
+ * @brief Helper function to read input and write to buffer.
+ *
+ * This function reallocates the buffer contained inside 
  * buf.
  * @param buf the buffer to pass in. If buffer is NULL, the function fails. If allocation fails, the function also
  * fails
@@ -138,12 +138,13 @@ static int smoldb_input_buf_read(InputBuf *buf, const char *input){
   size_t length = strlen(input);
   free(buf->buffer);
 
-  buf->buffer = (char*)malloc(sizeof(char)*(1 + length));
+  buf->buffer = (char*)malloc(sizeof(char)*(length));
   if (buf->buffer == NULL){
     perror(RED BOLD "Error allocating memory!\n" RESET_ALL);
     return SMOLDB_ALLOC_ERR;
   }
   strncpy(buf->buffer, input, length);
+  buf->buf_len = length;
   return SMOLDB_ALLOC_SUCCESS;
 }
 

--- a/src/cli/cli-handler.c
+++ b/src/cli/cli-handler.c
@@ -94,10 +94,10 @@ int prompt_prototype(InputBuf *buf, int argc, char *args[]){
       if (len > 0 && prompt_input[len - 1] == '\n') {
           prompt_input[len - 1] = '\0';
       }
-
-      if (strcmp(prompt_input, "") == 0) {
-          continue;  // If input is empty, display the prompt again
+      else if (len <= 0) {
+          continue;
       }
+
       smoldb_input_buf_read(buf, prompt_input);
       if (strcmp(prompt_input, "mogging") == 0){
         printf(YELLOW BOLD "Bro can rizz now!\n" RESET_ALL);

--- a/src/cli/cli-handler.c
+++ b/src/cli/cli-handler.c
@@ -1,11 +1,10 @@
 #include "cli-handler.h"
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <time.h>
+
 #include "retval.h"
 
 #define RESET_ALL "\033[0m"
@@ -28,83 +27,13 @@
 #define DIM "\033[2m"
 #define ITALIC "\033[3m"
 #define UNDERLINE "\033[4m"
-#define STRIKETHROUGH "\033[9m" 
+#define STRIKETHROUGH "\033[9m"
 #define CLEAR_SCREEN "\033[H\033[J"
 
 struct InputBuf {
   char *buffer;
   size_t buf_len;
 };
-
-void animate_intro() {
-    char intro[] = "Welcome to Mogwarts University!";
-    size_t len = strlen(intro);
-    size_t index = 0;
-
-    while (index < len) {
-        printf(CLEAR_SCREEN);
-        printf(GREEN BOLD); 
-
-        for (size_t i = 0; i < len; i++) {
-            if (i == index) {
-                printf("%c", toupper(intro[i]));
-            } else {
-                printf("%c", intro[i]);
-            }
-        }
-
-        printf(RESET_ALL);    
-        fflush(stdout);         
-
-        struct timespec req;
-        req.tv_sec = 0;
-        req.tv_nsec = 100000000L;  
-        nanosleep(&req, NULL);     
-        index++;            
-    }
-    printf("\n");
-}
-
-static int smoldb_input_buf_read(InputBuf *buf, const char *input);
-
-/**
- * @brief This function handle the input of user and create a prompt 
- * @param buf for buffer, argc = number of arguments, *args[] = array of arguments
- * @return status: 0 = success, 1 = failed
- */
-int prompt_prototype(InputBuf *buf, int argc, char *args[]){
-  if (buf == NULL){
-    perror(RED BOLD "Point to NULL\n" RESET_ALL);
-    return SMOLDB_NULL_PTR_TO_REF_ERR;
-  };
-  animate_intro();
-  printf(YELLOW BOLD "~~What do you want to learn to day?~~ \n" RESET_ALL);
-  if (argc == 2 && strcmp(args[1], "exit") != 0){
-    while (true){
-      printf(">>> ");
-      char prompt_input[1000];
-      if (fgets(prompt_input, sizeof(prompt_input), stdin) == NULL) {
-          break;  // EOF
-      }
-      // Remove the newline character at the end of the input
-      size_t len = strlen(prompt_input);
-      if (len > 0 && prompt_input[len - 1] == '\n') {
-          prompt_input[len - 1] = '\0';
-      }
-      else if (len <= 0) {
-          continue;
-      }
-
-      smoldb_input_buf_read(buf, prompt_input);
-      if (strcmp(prompt_input, "mogging") == 0){
-        printf(YELLOW BOLD "Bro can rizz now!\n" RESET_ALL);
-        return 0;        
-      }
-    }
-  }
-  printf(BOLD "\nBro is NOT Jordan Barrett\n" RESET_ALL);
-  return 1;
-}
 
 int smoldb_new_input_buf(InputBuf **buf) {
   if (buf == NULL) {
@@ -120,33 +49,6 @@ int smoldb_new_input_buf(InputBuf **buf) {
 
   return SMOLDB_ALLOC_SUCCESS;
 }
-/**
- * @brief Helper function to read input and write to buffer.
- *
- * This function reallocates the buffer contained inside 
- * buf.
- * @param buf the buffer to pass in. If buffer is NULL, the function fails. If allocation fails, the function also
- * fails
- * @return SMOLDB_ALLOC_SUCCESS if succeeded, SMOLDB_ALLOC_ERR if fail
- */
-static int smoldb_input_buf_read(InputBuf *buf, const char *input){
-  if (buf == NULL){
-    perror(RED BOLD "Point to NULL\n" RESET_ALL);
-    return SMOLDB_NULL_PTR_TO_REF_ERR;
-  }
-  size_t length = strlen(input);
-  free(buf->buffer);
-
-  buf->buffer = (char*)malloc(sizeof(char)*(length));
-  if (buf->buffer == NULL){
-    perror(RED BOLD "Error allocating memory!\n" RESET_ALL);
-    return SMOLDB_ALLOC_ERR;
-  }
-  strncpy(buf->buffer, input, length);
-  buf->buf_len = length;
-  return SMOLDB_ALLOC_SUCCESS;
-}
-
 
 int smoldb_free_input_buf(InputBuf **buf) {
   if (buf == NULL) {
@@ -157,6 +59,48 @@ int smoldb_free_input_buf(InputBuf **buf) {
   (*buf)->buffer = NULL;
   free((*buf));
   (*buf) = NULL;
+
+  return SMOLDB_ALLOC_SUCCESS;
+}
+
+/**
+ * @brief Reads the input from stdin and write into the input buffer passed in.
+ *
+ * NOTE: This operation reallocates the input buffer's inner string once.
+ *
+ * @return SMOLDB_ALLOC_SUCCESS (0) if nothing goes wrong, SMOLDB_NULL_PTR_ERR
+ * if buf is NULL, SMOLDB_ALLOC_ERR if memory reallocation fails.
+ */
+static int smoldb_get_input(InputBuf *buf) {
+  if (buf == NULL) {
+    return SMOLDB_NULL_PTR_ERR;
+  }
+  printf(">>> ");
+  ssize_t byteread = getline(&buf->buffer, &buf->buf_len, stdin);
+  if (byteread <= 0) {
+    return SMOLDB_ALLOC_ERR;
+  }
+  // ignore newline
+  buf->buf_len = -1 + byteread;
+  buf->buffer[byteread - 1] = '\0';
+  return SMOLDB_ALLOC_SUCCESS;
+}
+
+int smoldb_handle_input(InputBuf *buf) {
+  while (true) {
+    int retcode = smoldb_get_input(buf);
+    if (retcode) {
+      return retcode;
+    }
+
+    // FIXME: Placeholder only
+    if (buf->buf_len == strlen(".exit") && strcmp(buf->buffer, ".exit") == 0) {
+      printf(YELLOW "Exited!\n" RESET_ALL);
+      // HACK: technically there is an allocation in smoldb_get_input
+      return SMOLDB_ALLOC_SUCCESS;
+    }
+    printf(RED "Unknown command: " BOLD "%s\n" RESET_ALL, buf->buffer);
+  }
 
   return SMOLDB_ALLOC_SUCCESS;
 }

--- a/src/cli/cli-handler.h
+++ b/src/cli/cli-handler.h
@@ -15,13 +15,16 @@ extern "C" {
 
 /**
  * @typedef InputBuf
- * @brief Holds information about user input or input from stdin
+ * @brief Holds information about user input or input from stdin. Basically a
+ * more convenient string.
  *
  */
 typedef struct InputBuf InputBuf;
 
 /**
  * @brief Allocate memory for a new input buffer
+ *
+ * NOTE: (*buf) can be NULL, but (**buf) can NOT be NULL.
  *
  * @param buf The pointer to the address of the input buffer to be allocated
  * memory
@@ -33,6 +36,8 @@ SMOL_API int smoldb_new_input_buf(InputBuf **buf);
  * @brief Free memory allocated to the input buffer specified, if any, and
  * points the pointer to NULL.
  *
+ * NOTE: (*buf) can be NULL, but (**buf) can NOT be NULL.
+ *
  * @param buf The pointer to the address of the input buffer to be freed
  * memory. After being freed, (*buf) = NULL.
  * @return 0 if successful or if buf is NULL (hence nothing to remove)
@@ -40,25 +45,15 @@ SMOL_API int smoldb_new_input_buf(InputBuf **buf);
 SMOL_API int smoldb_free_input_buf(InputBuf **buf);
 
 /**
- * @brief Prototype to handle prompt. 
+ * @brief Prompt and get user input
  *
- * @param InputBuf* buf 
- * @param argc the number of arguments 
- * @param args the list of the arguments. 
- *
- * The arguments argc and args are expected to be passed from main(). At least one
- * command-line argument other than the executable is expected. If the user writes
- * input, the function reallocates memory for buf's buffer string.
- *
- * @return If the user insert "mogging" when prompted, the function returns 0.
- * If user does not provide any command-line argument, or the argument is "exit",
- * the function returns 1.
-*/
-SMOL_API int prompt_prototype(InputBuf *buf, int argc, char *args[]);
+ * @param buf
+ * @return
+ */
+extern int smoldb_handle_input(InputBuf *buf);
 
 #ifdef __cplusplus
 }
 #endif  // __cplusplus
 
 #endif  // !SMOLDB_CLI_HANDLER_H
-

--- a/src/cli/cli-handler.h
+++ b/src/cli/cli-handler.h
@@ -40,19 +40,19 @@ SMOL_API int smoldb_new_input_buf(InputBuf **buf);
 SMOL_API int smoldb_free_input_buf(InputBuf **buf);
 
 /**
- * @brief Prototype to handle prompt, it will get what the user type in and change it into InputBuf
- * @param InputBuf* buf is a pointer point to the InputBuf, argc is the number of arguments, and args is
- * the list of the arguments. Such as when user runs the program like this: 
- * ./smoldb.exe run --> We will have 2 arguments, the former is ./smoldb.exe, and the latter is run.
- * Inside the function, I also have a supporting function named 
- * int smoldb_input_buf_read(InputBuf *buf, const char *input)
- * In this function, my main purpose is that whenever the user insert a new "input" string, the content
- * of the string will be assigned to the string buffer in InputBuf, and the length of the string will also 
- * be assigned to buf_len.
- * Inside the smoldb_input_buf_read function, I reallocate the memory space for InputBuf with the lenght of 
- * the input, and copy the content of the input string to the string buffer.
- * @return status of the prompt. If the user insert the proper input, the function will return 0, else it will
- * return 1.
+ * @brief Prototype to handle prompt. 
+ *
+ * @param InputBuf* buf 
+ * @param argc the number of arguments 
+ * @param args the list of the arguments. 
+ *
+ * The arguments argc and args are expected to be passed from main(). At least one
+ * command-line argument other than the executable is expected. If the user writes
+ * input, the function reallocates memory for buf's buffer string.
+ *
+ * @return If the user insert "mogging" when prompted, the function returns 0.
+ * If user does not provide any command-line argument, or the argument is "exit",
+ * the function returns 1.
 */
 SMOL_API int prompt_prototype(InputBuf *buf, int argc, char *args[]);
 

--- a/src/entry.c
+++ b/src/entry.c
@@ -4,14 +4,16 @@
 #include "cli-handler.h"
 #include "retval.h"
 
-int main(int argc, char *argv[]) {
+int main(/*int argc, char *argv[]*/) {
+  // HACK: InputBuf is managed by main() due to the fact that its lifetime is
+  // the same as the program's lifetime
   InputBuf *buf = NULL;
   int retval = smoldb_new_input_buf(&buf);
-  prompt_prototype(buf, argc, argv);
   if (retval == SMOLDB_ALLOC_ERR) {
     smoldb_free_input_buf(&buf);
     return EXIT_FAILURE;
   }
+  smoldb_handle_input(buf);
   smoldb_free_input_buf(&buf);
   return EXIT_SUCCESS;
 }

--- a/src/retval.h
+++ b/src/retval.h
@@ -15,10 +15,12 @@ typedef enum SMOL_ALLOC_RETVAL {
 
   /* The pointer to address is NULL,
    * NOTE: this won't happen to NULL pointer (void*) but only to null
-   * pointer-to-pointer (void**)
+   * pointer-to-pointer (void**), and only happens when a function asks
+   * for pointer-to-pointer
    *
    * */
   SMOLDB_NULL_PTR_TO_REF_ERR,
+  SMOLDB_NULL_PTR_ERR,
 } SMOLDB_ALLOC_RETVAL;
 
 /**


### PR DESCRIPTION
# A more formal implementation of your pull request

[Here is the original PR](huynguyen-and-friend-projects/smoldb#29)
- **What**:

Since the proposed change is a "prototype", I think that means I can change things, completely, like this.
Better utilize the InputBuf, through getline() instead of fgets().
Add a placeholder handler for ".exit" and remove every other commands, for now.
Also chopped the animation.

- **Why**:

One may say this is an aggressive (and opinionated) change.
getline() doesn't require a temporary buffer like fgets() does. The function automatically allocates memory for InputBuf's inner string.
The animation is cool in the first few tries, but gets old pretty quick. So I decided to chop it. Although, I advise you keep the animation in a "legacy" branch. I wouldn't want that to disappear completely to be honest.

- **Misc**:

You can merge this without merging #1 first.

This contains a merge conflict. Be sure to resolve that also. 

- **Tags**:

@BAOELIETRAN 

---

Pull request by: Huy Nguyen
